### PR TITLE
Refactor : 회원 탈퇴 시 soft delete로 동작하도록 변경

### DIFF
--- a/src/main/java/com/example/gasip/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/gasip/global/constant/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     // Member
     NOT_FOUND_MEMBER("회원 정보가 없습니다. 로그인 후 이용해주세요."),
     DUPLICATE_MEMBER("이미 등록된 회원입니다."),
+    WITHDRAWED_MEMBER("탈퇴한 회원입니다."),
     // Professor
     NOT_FOUND_PROFESSOR("교수 정보 조회 불가 오류"),
     //Board

--- a/src/main/java/com/example/gasip/member/controller/MemberController.java
+++ b/src/main/java/com/example/gasip/member/controller/MemberController.java
@@ -239,4 +239,20 @@ public class MemberController {
             );
     }
 
+    @PostMapping("/restore")
+    @Tag(name = "Service Member Interface", description = "회원 복구 api 입니다.")
+    @Operation(summary = "회원 복구", description = "회원 복구 api 입니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", content = {@Content(mediaType = "application/json")})
+    })
+    public ResponseEntity restoreAccount(@AuthenticationPrincipal MemberDetails memberDetails) {
+        return ResponseEntity
+            .ok()
+            .body(
+                ApiUtils.success(
+                    memberService.restoreAccount(memberDetails)
+                )
+            );
+    }
+
 }

--- a/src/main/java/com/example/gasip/member/dto/MemberSignUpRequest.java
+++ b/src/main/java/com/example/gasip/member/dto/MemberSignUpRequest.java
@@ -40,6 +40,7 @@ public class MemberSignUpRequest {
             .name(name)
             .nickname(nickname)
             .role(Role.MEMBER)
+            .isWithDraw(false)
             .build();
 
     }

--- a/src/main/java/com/example/gasip/member/model/Member.java
+++ b/src/main/java/com/example/gasip/member/model/Member.java
@@ -38,17 +38,21 @@ public class Member {
     @Schema(description = "권한", example = "MEMBER")
     private Role role;
 
+    @Schema(description = "탈퇴여부", example = "true/false")
+    private Boolean isWithDraw;
+
     @Builder
-    private Member(String email, String name, String nickname, String password, Role role) {
+    private Member(String email, String name, String nickname, String password, Role role, Boolean isWithDraw) {
         this.email = email;
         this.name = name;
         this.nickname = nickname;
         this.password = password;
         this.role = role;
+        this.isWithDraw = isWithDraw;
     }
 
     public static Member create(String email, String name, String nickname, String password, Role role) {
-        return new Member(email, name, nickname,password, role);
+        return new Member(email, name, nickname,password, role,false);
     }
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
@@ -61,5 +65,9 @@ public class Member {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void updateMemberWithdrawalStatus(Boolean value) {
+        this.isWithDraw = value;
     }
 }


### PR DESCRIPTION
## 작업 요약
- 컨트롤러/서비스 회원 탈퇴 로직 수정
- 회원 복구 로직 추가
- Member 클래스 내 isWithDraw 칼럼 추가
## Issue Link
#323 
## 문제점 및 어려움
- 탈퇴한 회원이 신규 회원가입 프로세스를 그대로 탈 시, 백엔드 코드 복잡성 증가
## 해결 방안
- 복구 프로세스는 별도로 가져가는 것을 추천 (논의 필요)
## Reference
