### PR TITLE
[백엔드] 키워드 '전체' 검색 시 빈 객체 반환하도록 변경

### DIFF
--- a/src/main/java/com/example/gasip/professor/controller/ProfessorController.java
+++ b/src/main/java/com/example/gasip/professor/controller/ProfessorController.java
@@ -121,4 +121,18 @@ public class ProfessorController {
                 );
     }
 
+    /**
+     * 학과/학부 키워드를 통한 교수 검색
+     */
+    @GetMapping("/search-test")
+    public ResponseEntity<?> findProfessorByProfessorNameLike(String profName,
+                                                              @AuthenticationPrincipal MemberDetails memberDetails) {
+        return ResponseEntity
+                .ok()
+                .body(
+                        ApiUtils.success(
+                                professorService.findProfessorByProfessorNameLike(profName, memberDetails)
+                        )
+                );
+    }
 }

--- a/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustom.java
+++ b/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustom.java
@@ -8,6 +8,9 @@ import java.util.List;
 public interface ProfessorRepositoryCustom {
     List<ProfessorWithBoardResponse> findBoardByProfessor(Long profId);
 
+    // 학과/학부 검색
     List<ProfessorResponse> findProfessorByCategoryNameContaining(String majorName);
+    // 교수 검색
+    List<ProfessorResponse> findProfessorByProfessorNameLike(String majorName);
 }
 

--- a/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustomImpl.java
@@ -35,4 +35,15 @@ public class ProfessorRepositoryCustomImpl implements ProfessorRepositoryCustom{
                 .where(professor.category.majorName.contains(majorName), (professor.category.Id.gt(0)))
                 .fetch();
     }
+
+    // 학과/학부 키워드를 통한 교수 검색
+    @Override
+    public List<ProfessorResponse> findProfessorByProfessorNameLike(String profName) {
+        return queryFactory
+                .select(new QProfessorResponse(
+                        professor.profId, professor.profName, professor.category.collegeName, professor.category.Id, professor.category.majorName))
+                .from(professor)
+                .where(professor.profName.like(profName), (professor.profId.gt(0)))
+                .fetch();
+    }
 }

--- a/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/professor/repository/ProfessorRepositoryCustomImpl.java
@@ -32,7 +32,7 @@ public class ProfessorRepositoryCustomImpl implements ProfessorRepositoryCustom{
                 .select(new QProfessorResponse(
                         professor.profId, professor.profName, professor.category.collegeName, professor.category.Id, professor.category.majorName))
                 .from(professor)
-                .where(professor.category.majorName.contains(majorName))
+                .where(professor.category.majorName.contains(majorName), (professor.category.Id.gt(0)))
                 .fetch();
     }
 }

--- a/src/main/java/com/example/gasip/professor/service/ProfessorService.java
+++ b/src/main/java/com/example/gasip/professor/service/ProfessorService.java
@@ -106,4 +106,30 @@ public class ProfessorService {
     public List<ProfessorResponse> findProfessorByCategoryNameContaining(String majorName) {
         return professorRepository.findProfessorByCategoryNameContaining(majorName);
     }
+
+    /**
+     * 학과/학부 키워드를 통한 교수 검색
+     */
+    @Transactional
+    public List<ProfessorResponse> findProfessorByProfessorNameLike(String professorName, MemberDetails memberDetails) {
+        Member member = memberRepository.findById(memberDetails.getId()).orElseThrow(
+                () -> new MemberNotFoundException(ErrorCode.NOT_FOUND_MEMBER)
+        );
+        List<ProfessorResponse> professors = professorRepository.findProfessorByProfessorNameLike(professorName);
+
+//        return professors.stream()
+//                .map(professor -> {
+//                    String averageGradePoint = gradeRepository.professorAverageGradepoint(professor.getProfId()).get(0).toString();
+//                    professor.updateProfessor(averageGradePoint);
+//                    if (gradeRepository.findAllByProfessorAndMember(professor, member).isEmpty()) {
+//                        professor.updateGrade(false);
+//                    } else {
+//                        professor.updateGrade(true);
+//                    }
+//                    return ProfessorResponse.fromEntity(professor);
+//                })
+//                .collect(Collectors.toList());
+
+        return professorRepository.findProfessorByProfessorNameLike(professorName);
+    }
 }

--- a/src/main/java/com/example/gasip/professor/service/ProfessorService.java
+++ b/src/main/java/com/example/gasip/professor/service/ProfessorService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -82,24 +81,12 @@ public class ProfessorService {
             .map(professor -> {
                 String averageGradePoint = gradeRepository.professorAverageGradepoint(professor.getProfId()).get(0).toString();
                 professor.updateProfessor(averageGradePoint);
-                if (Objects.equals(professorName, "전체")) {
-                    return null;
+                if (gradeRepository.findAllByProfessorAndMember(professor, member).isEmpty()) {
+                    professor.updateGrade(false);
                 } else {
-                    if (gradeRepository.findAllByProfessorAndMember(professor, member).isEmpty()) {
-                        professor.updateGrade(false);
-                    } else {
-                        professor.updateGrade(true);
-                    }
-
-                    return ProfessorResponse.fromEntity(professor);
+                    professor.updateGrade(true);
                 }
-//                if (gradeRepository.findAllByProfessorAndMember(professor, member).isEmpty()) {
-//                    professor.updateGrade(false);
-//                } else {
-//                    professor.updateGrade(true);
-//                }
-//
-//                return ProfessorResponse.fromEntity(professor);
+                return ProfessorResponse.fromEntity(professor);
             })
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 작업 요약
교수이름, 학과/학부 키워드 '전체' 검색 시 빈 객체 반환하도록 변경
-> Querydsl에서 where절 필터링을 통해 구현
## Issue Link
#326 
## 문제점 및 어려움
- 예외 처리를 해야하는지 sql을 통해 필터링을 하는게 맞는지 모르겠음
- 더 좋은 해결방안 탐색 필요함
## 해결 방안
- Id 값이 0 이상인 데이터만 검색하도록 구현
## Reference
