### PR TITLE
Publish : FCM 설정 추가

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,6 +32,12 @@ jobs:
           echo "${{ secrets.APPLICATION_YML }}" | base64 --decode > src/main/resources/application-dev.yml
           find src
 
+      - name: Set FCM.json
+        run: |
+          mkdir -p src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_SECRET_ADMIN }}" | base64 --decode > src/main/resources/firebase/gasip-4eb42-firebase-adminsdk-3v4pj-6851019caa.json
+          find src
+
       - name: Build with Gradle
         run: ./gradlew build --scan
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GASIP : 가천대학교 재학생/졸업생 대상 가천대 교수님 익명 리뷰 서비스
-
+- 스레드 풀 테스트 중
 <div align="center">
   <br>
   <img width="234" alt="image" src="https://github.com/GASIP-PROJECT/gasip-backend/assets/114489245/55e77169-b2fa-4220-ba23-349dcb8d41ed">

--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -206,14 +206,14 @@ public class BoardController {
      * 알림 설정
      */
     @PostMapping("/api/fcm")
-    public ResponseEntity pushMessage(@RequestBody BoardPushRequest boardPushRequest) throws IOException {
+    public ResponseEntity<?> pushMessage(@RequestBody BoardPushRequest boardPushRequest) throws IOException {
         System.out.println(boardPushRequest.getTargetToken() + " "
-            +boardPushRequest.getTitle() + " " + boardPushRequest.getBody());
+            + boardPushRequest.getTitle() + " " + boardPushRequest.getBody());
 
-        firebasePushService.sendMessageTo(
-            boardPushRequest.getTargetToken(),
-            boardPushRequest.getTitle(),
-            boardPushRequest.getBody());
-        return ResponseEntity.ok().build();
+        return ResponseEntity
+            .ok()
+            .body(
+                ApiUtils.success(firebasePushService.sendMessageTo(boardPushRequest))
+            );
     }
 }

--- a/src/main/java/com/example/gasip/board/dto/BoardPushRequest.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardPushRequest.java
@@ -1,10 +1,21 @@
 package com.example.gasip.board.dto;
 
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardPushRequest {
     private String targetToken;
     private String title;
     private String body;
+
+    @Builder(toBuilder = true)
+    public BoardPushRequest(String targetToken, String title, String body) {
+        this.targetToken = targetToken;
+        this.title = title;
+        this.body = body;
+    }
 }

--- a/src/main/java/com/example/gasip/board/dto/FcmMessageRequest.java
+++ b/src/main/java/com/example/gasip/board/dto/FcmMessageRequest.java
@@ -1,4 +1,4 @@
-package com.example.gasip.global.entity;
+package com.example.gasip.board.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 @Getter
-public class FcmMessage {
+public class FcmMessageRequest {
     private boolean validateOnly;
     private Message message;
 

--- a/src/main/java/com/example/gasip/board/service/FirebasePushService.java
+++ b/src/main/java/com/example/gasip/board/service/FirebasePushService.java
@@ -1,6 +1,7 @@
 package com.example.gasip.board.service;
 
-import com.example.gasip.global.entity.FcmMessage;
+import com.example.gasip.board.dto.BoardPushRequest;
+import com.example.gasip.board.dto.FcmMessageRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -20,8 +22,8 @@ public class FirebasePushService {
     private final String API_URL = "https://fcm.googleapis.com/v1/projects/gasip-4eb42/messages:send";  // 요청을 보낼 엔드포인트
     private final ObjectMapper objectMapper;
 
-    public void sendMessageTo(String targetToken, String title, String body) throws IOException {
-        String message = makeMessage(targetToken, title, body);
+    public int sendMessageTo(BoardPushRequest boardPushRequest) throws IOException {
+        String message = makeMessage(boardPushRequest.getTargetToken(), boardPushRequest.getTitle(), boardPushRequest.getBody());
 
         OkHttpClient client = new OkHttpClient();
         RequestBody requestBody = RequestBody.create(message,
@@ -36,24 +38,25 @@ public class FirebasePushService {
         Response response = client.newCall(request).execute();
 
         System.out.println(response.body().string());
+        return response.code() == HttpURLConnection.HTTP_OK ? 1 : 0;
     }
 
     private String makeMessage(String targetToken, String title, String body) throws JsonParseException, JsonProcessingException {
-        FcmMessage fcmMessage = FcmMessage.builder()
-            .message(FcmMessage.Message.builder()
+        FcmMessageRequest fcmMessageRequest = FcmMessageRequest.builder()
+            .message(FcmMessageRequest.Message.builder()
                 .token(targetToken)
-                .notification(FcmMessage.Notification.builder()
+                .notification(FcmMessageRequest.Notification.builder()
                     .title(title)
                     .body(body)
                     .image(null)
                     .build()
                 ).build()).validateOnly(false).build();
 
-        return objectMapper.writeValueAsString(fcmMessage);
+        return objectMapper.writeValueAsString(fcmMessageRequest);
     }
 
     private String getAccessToken() throws IOException {
-        String firebaseConfigPath = "firebase/firebase_service_key.json";
+        String firebaseConfigPath = "firebase/gasip-4eb42-firebase-adminsdk-3v4pj-6851019caa.json";
 
         GoogleCredentials googleCredentials = GoogleCredentials
             .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())


### PR DESCRIPTION
## 작업 요약
- FCM 설정 추가
- CI 스크립트에 FCM 시크릿 json 가져오도록 수정
## Issue Link

## 문제점 및 어려움
1. 깃허브 시크릿에 json 파일 저장하는 것을 지양해야하나,현재 json을 저장한 상태 & 제대로 동작할지 확인 필요
## 해결 방안
1. base64로 인코딩하여 저장. 다만 저장을 지양해야하는 이유 확인 필요
## Reference
https://velog.io/@wellbeing-dough/FCM-secret.json%EC%9D%84-CICD%EC%97%90%EC%84%9C-%EC%88%A8%EA%B2%A8%EC%84%9C-%EB%B0%B0%ED%8F%AC%ED%95%98%EA%B8%B0