### PR TITLE
Feature/#349 인기글캐싱도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:9.2.0'
     implementation 'org.springframework.cloud:spring-cloud-gcp-starter:1.2.8.RELEASE'
 
+    //인기글 캐싱
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
+
 }
 tasks.named('bootBuildImage') {
     builder = 'paketobuildpacks/builder-jammy-base:latest'

--- a/src/main/java/com/example/gasip/board/dto/BoardReadResponse.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardReadResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Getter
@@ -17,7 +18,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @Schema(description = "게시글 읽기 Response DTO 관련 VO")
 @AllArgsConstructor
-public class BoardReadResponse extends BaseTimeEntity {
+public class BoardReadResponse extends BaseTimeEntity implements Serializable {
     @NotNull
     @Schema(description = "게시글 ID")
     private Long postId;

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustom.java
@@ -24,7 +24,7 @@ public interface BoardRepositoryCustom {
 
     List<BoardReadResponse> findByProfNameLike(String profName);
 
-    List<BoardReadResponse> findBestBoard(Pageable pageable);
+    List<BoardReadResponse> findBestBoard();
 
     /**
      * 교수 상세정보 넘기기

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
@@ -140,7 +140,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
             .where(board.likeCount.goe(5))
             .orderBy(board.regDate.desc())
             .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
+            .limit(Math.min(pageable.getPageSize(),30))
             .fetch();
     }
 

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
@@ -128,7 +128,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
     }
 
     @Override
-    public List<BoardReadResponse> findBestBoard(Pageable pageable) {
+    public List<BoardReadResponse> findBestBoard() {
         return queryFactory
             .select(new QBoardReadResponse(
                 board.regDate, board.updateDate, board.postId, board.member.nickname,
@@ -139,8 +139,7 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
             .leftJoin(board.professor, professor)
             .where(board.likeCount.goe(5))
             .orderBy(board.regDate.desc())
-            .offset(pageable.getOffset())
-            .limit(Math.min(pageable.getPageSize(),30))
+            .limit(30)
             .fetch();
     }
 

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -20,6 +20,7 @@ import com.example.gasip.member.repository.MemberRepository;
 import com.example.gasip.professor.model.Professor;
 import com.example.gasip.professor.repository.ProfessorRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -156,6 +157,7 @@ public class BoardService {
         return boardId + "번 게시글이 삭제되었습니다.";
     }
     @Transactional(readOnly = true)
+    @Cacheable
     public List<BoardReadResponse> findBestBoard(MemberDetails memberDetails,Pageable pageable) {
         List<BoardReadResponse> boardReadResponses = boardRepository.findBestBoard(pageable);
         List<BoardReadResponse> bestBoardReadResponseList = new ArrayList<>();

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -42,6 +42,7 @@ public class BoardService {
     private final MemberRepository memberRepository;
     private final ProfessorRepository professorRepository;
     private final RedisViewCountService redisViewCountService;
+    private final RedisBestBoardService redisBestBoardService;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
     private final CommentLikesRepository commentLikesRepository;
@@ -159,6 +160,12 @@ public class BoardService {
     @Transactional(readOnly = true)
     @Cacheable
     public List<BoardReadResponse> findBestBoard(MemberDetails memberDetails,Pageable pageable) {
+        return redisBestBoardService.getData("bestBoard");
+    }
+//    @Scheduled(cron = "* */10 * * * *",zone = "Asia/Seoul")
+    //TODO 파라미터 빼고 cron 어케 적용하징..?
+    @Transactional(readOnly = true)
+    public List<BoardReadResponse> insertBestBoardListRedis(MemberDetails memberDetails,Pageable pageable) {
         List<BoardReadResponse> boardReadResponses = boardRepository.findBestBoard(pageable);
         List<BoardReadResponse> bestBoardReadResponseList = new ArrayList<>();
         for (BoardReadResponse boardReadResponse : boardReadResponses) {
@@ -169,8 +176,10 @@ public class BoardService {
             }
             bestBoardReadResponseList.add(BoardReadResponse.fromEntity(board));
         }
+        redisBestBoardService.addBestBoardList(bestBoardReadResponseList);
         return bestBoardReadResponseList;
     }
+
     @Transactional
     public Board insertView(Long postId,Member member) {
         String viewCount = redisViewCountService.getData(String.valueOf(member.getMemberId()));

--- a/src/main/java/com/example/gasip/board/service/RedisBestBoardService.java
+++ b/src/main/java/com/example/gasip/board/service/RedisBestBoardService.java
@@ -1,0 +1,25 @@
+package com.example.gasip.board.service;
+
+import com.example.gasip.board.dto.BoardReadResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RedisBestBoardService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void addBestBoardList(List<BoardReadResponse> bestBoardReadResponseList) {
+        ValueOperations<String,Object> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set("bestBoard", bestBoardReadResponseList);
+    }
+
+    public List<BoardReadResponse> getData(String key) {
+        ValueOperations<String,Object> valueOperations = redisTemplate.opsForValue();
+        return (List<BoardReadResponse>) valueOperations.get(key);
+    }
+}

--- a/src/main/java/com/example/gasip/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/gasip/global/config/RedisCacheConfig.java
@@ -1,0 +1,28 @@
+package com.example.gasip.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager contentCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())) // Value Serializer 변경
+            .entryTtl(Duration.ofMinutes(1L)); // 캐시 수명 10분
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
+}

--- a/src/main/java/com/example/gasip/global/config/RedisConfig.java
+++ b/src/main/java/com/example/gasip/global/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.example.gasip.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/example/gasip/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/gasip/global/entity/BaseTimeEntity.java
@@ -1,5 +1,9 @@
 package com.example.gasip.global.entity;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
@@ -25,11 +29,15 @@ public abstract class BaseTimeEntity {
     @CreatedDate // Entity 생성 시 시간 저장
     @Column(updatable = false, name = "reg_date")
     @Schema(description = "작성 시간")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime regDate;
 
     @LastModifiedDate // 조회한 Entity 값 변경 시 시간 저장
     @Column(name = "update_date")
     @Schema(description = "수정 시간")
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     protected LocalDateTime updateDate;
 
     public BaseTimeEntity(LocalDateTime regDate, LocalDateTime updateDate) {


### PR DESCRIPTION
## 작업 요약
- 인기글 조회 로직 개선
    - 10분에 1번씩 인기글 조회후 최신 30개만 레디스에 저장
- 클라이언트 요청 시 레디스에 저장된 인기글 제공
## Issue Link
#349 
## 문제점 및 어려움
1. @Schedule 어노테이션 활용 시 파라미티 제외 필수. 그러나 findBestBoard 메서드는 queryDSL로 구현되며 Pageable을 필수로 받고 있음
## 해결 방안
1. Pageable 없이 인기글30개만 레디스에 저장. 이후 클라이언트 요청 시에만 Pageable이 필요하므로 해당 api에만 구현
## Reference
