### PR TITLE
배포시 디스코드 웹 훅 알림 오지 않는 버그 수정 

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -21,7 +21,6 @@ NOW=$(date +%c)
 
 
 echo "[$NOW] > $JAR_PATH 실행" >> $START_LOG
-nohup java -jar $JAR_PATH --spring.profiles.active=dev &
-#nohup java -jar $JAR_PATH 1> $APP_LOG 2> $ERROR_LOG &
+nohup java -jar $JAR_PATH --spring.profiles.active=dev > $APP_LOG 2> $ERROR_LOG &
 
 echo "[$NOW] > 서비스 PID: $SERVICE_PID" >> $START_LOG


### PR DESCRIPTION
## 작업 요약
- 배포 시 디스코드 웹 훅 작동되지 않는 문제 해결
- 배포시 dev 환경에서 실행
- log 파일 추가
## Issue Link
#416 
## 문제점 및 어려움
- ec2 환경에서 배포 시 알림이 오지 않는 원인을 찾는라 힘들었음
- profiles.activate를 dev로 설정해주지 않아 알림이 오지 않았음
## 해결 방안
- 배포 시 --spring.profiles.active=dev 코드를 통해 dev 환경에서 실행되도록 설정 
## Reference
