### PR TITLE
Refactor : 카테고리 도메인 내 사용하지 않는 api 정리 및 querydsl 리팩토링

### DIFF
--- a/src/main/java/com/example/gasip/category/controller/CategoryController.java
+++ b/src/main/java/com/example/gasip/category/controller/CategoryController.java
@@ -28,18 +28,7 @@ public class CategoryController {
                 );
     }
 
-    @GetMapping("/majors")
-    public ResponseEntity<?> findCategory() {
-        return ResponseEntity
-            .ok()
-            .body(
-                ApiUtils.success(
-                    categoryService.findCategory()
-                )
-            );
-    }
-
-    @GetMapping("/majors/{parentCategory_id}")
+    @GetMapping("/{parentCategory_id}")
     public ResponseEntity<?> findCategoryByParentCategory(@PathVariable Category parentCategory_id) {
         return ResponseEntity
             .ok()
@@ -50,7 +39,7 @@ public class CategoryController {
             );
     }
 
-    @GetMapping("/majors/{parentCategory_id}/{Id}")
+    @GetMapping("/{parentCategory_id}/{Id}")
     public ResponseEntity<?> findCategoryByMajorId(@PathVariable Long Id) {
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/example/gasip/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/gasip/category/repository/CategoryRepository.java
@@ -2,15 +2,12 @@ package com.example.gasip.category.repository;
 
 import com.example.gasip.category.model.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryRepositoryCustom {
-    @Query("select c from Category c where c.parentCategory is NULL")
-    List<Category> findCategory();
 
     //TODO : 전체 카테고리 제외 한 결과 반환하도록 querydsl로 리팩토링
     List<Category> findCategoryByParentCategory(Category parentCategory_id);

--- a/src/main/java/com/example/gasip/category/repository/CategoryRepositoryCustom.java
+++ b/src/main/java/com/example/gasip/category/repository/CategoryRepositoryCustom.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface CategoryRepositoryCustom {
     List<CategoryResponse> findAllByParentCategory();
+
 }

--- a/src/main/java/com/example/gasip/category/service/CategoryService.java
+++ b/src/main/java/com/example/gasip/category/service/CategoryService.java
@@ -37,14 +37,6 @@ public class CategoryService {
     }
 
     @Transactional
-    public List<CategoryDto> findCategory() {
-        return categoryRepository.findCategory()
-            .stream()
-            .map(CategoryDto::toEntity)
-            .collect(Collectors.toList());
-    }
-
-    @Transactional
     public List<CategoryDto> findCategoryByParentCategory(Category parentCategory_id) {
         return categoryRepository.findCategoryByParentCategory(parentCategory_id)
             .stream()


### PR DESCRIPTION
## 작업 요약
- 카테고리 도메인 내 findCategory 삭제
- api 주소 변경("/majors" 삭제)
## Issue Link
#468 
## 문제점 및 어려움
x
## 해결 방안

## Reference
