### PR TITLE
feat : 게시글 및 댓글 신고 기능 구현

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -1,39 +1,39 @@
-version: 0.0
-os: linux
-files:
-  - source: /
-    destination: /home/ec2-user/app
-    overwrite: yes
-
-permissions:
-  - object: /
-    pattern: "**"
-    owner: ec2-user
-    group: ec2-user
-
-hooks:
-  ApplicationStart:
-    - location: deploy.sh
-      timeout: 60
-      runas: ec2-user
-
 #version: 0.0
 #os: linux
-#
 #files:
-#  - source:  /
-#    destination: /home/ubuntu/spring-github-action
+#  - source: /
+#    destination: /home/ec2-user/app
 #    overwrite: yes
 #
 #permissions:
 #  - object: /
-#    owner: ubuntu
-#    group: ubuntu
+#    pattern: "**"
+#    owner: ec2-user
+#    group: ec2-user
 #
 #hooks:
-#  AfterInstall:
-#    - location: scripts/stop.sh
-#      timeout: 60
 #  ApplicationStart:
-#    - location: scripts/start.sh
+#    - location: deploy.sh
 #      timeout: 60
+#      runas: ec2-user
+
+version: 0.0
+os: linux
+
+files:
+  - source:  /
+    destination: /home/ubuntu/spring-github-action
+    overwrite: yes
+
+permissions:
+  - object: /
+    owner: ubuntu
+    group: ubuntu
+
+hooks:
+  AfterInstall:
+    - location: scripts/stop.sh
+      timeout: 60
+  ApplicationStart:
+    - location: scripts/start.sh
+      timeout: 60

--- a/src/main/java/com/example/gasip/board/controller/BoardController.java
+++ b/src/main/java/com/example/gasip/board/controller/BoardController.java
@@ -47,6 +47,20 @@ public class BoardController {
                 )
             );
     }
+
+    @PutMapping("/change/{postId}")
+    public ResponseEntity<?> changeActivity(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable Long postId) {
+        return ResponseEntity
+                .ok()
+                .body(
+                        ApiUtils.success(
+                                boardService.changeActivity(memberDetails, postId)
+                        )
+                );
+    }
+
     //TODO 쓰는 API인지 확인 필요
     @GetMapping("/all-boards")
     @Operation(summary = "전체 리뷰 정보 요청", description = "모든 게시글 목록을 최신순으로 불러옵니다.", tags = {"Board Controller"})
@@ -127,7 +141,7 @@ public class BoardController {
             .ok()
             .body(
                 ApiUtils.success(
-                    boardService.editBoard(memberDetails, postId,boardUpdateRequest)
+                    boardService.editBoard(memberDetails, postId, boardUpdateRequest)
                 )
             );
 

--- a/src/main/java/com/example/gasip/board/dto/BoardActivityRequestDto.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardActivityRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.gasip.board.dto;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.board.model.ContentActivity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "게시글 수정 Request DTO 관련 VO")
+public class BoardActivityRequestDto {
+    private ContentActivity contentActivity;
+
+    public Board toEntity(BoardActivityRequestDto boardActivityRequestDto) {
+        return Board.builder()
+                .contentActivity(boardActivityRequestDto.getContentActivity())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/board/dto/BoardActivityResponseDto.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardActivityResponseDto.java
@@ -1,0 +1,45 @@
+package com.example.gasip.board.dto;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.board.model.ContentActivity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BoardActivityResponseDto {
+    @NotNull
+    @Schema(description = "게시글 ID")
+    private Long postId;
+    @NotNull
+    @Schema(description = "게시글 내용")
+    private String content;
+    @NotNull
+    @Schema(description = "게시글과 관련된 교수 정보")
+    private Long professor;
+    @NotNull
+    private Long reportCount;
+    @NotNull
+    private ContentActivity contentActivity;
+
+    @Builder
+    public BoardActivityResponseDto(Long postId, String content, Long professor, Long reportCount, ContentActivity contentActivity) {
+        this.postId = postId;
+        this.content = content;
+        this.professor = professor;
+        this.reportCount = reportCount;
+        this.contentActivity = contentActivity;
+    }
+
+    public static BoardActivityResponseDto fromEntity(Board board) {
+        return BoardActivityResponseDto.builder()
+                .postId(board.getPostId())
+                .content(board.getContent())
+                .professor(board.getProfessor().getProfId())
+                .contentActivity(board.getContentActivity())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/board/dto/BoardCreateRequest.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.gasip.board.dto;
 
+import com.example.gasip.board.model.ContentActivity;
 import com.example.gasip.global.entity.BaseTimeEntity;
 import com.example.gasip.board.model.Board;
 import com.example.gasip.member.model.Member;
@@ -27,6 +28,7 @@ public class BoardCreateRequest extends BaseTimeEntity {
     private Professor professor;
     @Schema(description = "게시글 작성한 사용자")
     private Member member;
+    private ContentActivity contentActivity = ContentActivity.GENERAL;
 
 
     public Board toEntity(Professor prof, Member mem) {
@@ -36,6 +38,7 @@ public class BoardCreateRequest extends BaseTimeEntity {
                 .likeCount(likeCount)
                 .professor(prof)
                 .member(mem)
+                .contentActivity(contentActivity)
                 .build();
     }
 

--- a/src/main/java/com/example/gasip/board/dto/BoardCreateResponse.java
+++ b/src/main/java/com/example/gasip/board/dto/BoardCreateResponse.java
@@ -1,7 +1,8 @@
 package com.example.gasip.board.dto;
 
-import com.example.gasip.global.entity.BaseTimeEntity;
 import com.example.gasip.board.model.Board;
+import com.example.gasip.board.model.ContentActivity;
+import com.example.gasip.global.entity.BaseTimeEntity;
 import com.example.gasip.professor.model.Professor;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -29,14 +30,16 @@ public class BoardCreateResponse extends BaseTimeEntity {
     @NotNull
     @Schema(description = "게시글과 관련된 교수 정보")
     private Long profId;
+    private ContentActivity contentActivity;
 
-    public BoardCreateResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Professor professor) {
+    public BoardCreateResponse(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Professor professor, ContentActivity contentActivity) {
         super(regDate, updateDate);
         this.postId = postId;
         this.content = content;
         this.clickCount = 0L;
         this.likeCount = 0L;
         this.profId = professor.getProfId();
+        this.contentActivity = contentActivity;
     }
 
     public BoardCreateResponse(Long postId, String content,Long profId) {
@@ -55,6 +58,7 @@ public class BoardCreateResponse extends BaseTimeEntity {
                 .clickCount(0L)
                 .likeCount(0L)
                 .profId(board.getProfessor().getProfId())
+                .contentActivity(board.getContentActivity())
                 .build();
     }
 

--- a/src/main/java/com/example/gasip/board/model/Board.java
+++ b/src/main/java/com/example/gasip/board/model/Board.java
@@ -94,7 +94,7 @@ public class Board extends BaseTimeEntity {
         this.professor = professor;
         this.member = member;
         this.comments = comments;
-        this.contentActivity = (contentActivity != null) ? contentActivity : ContentActivity.GENERAL;
+        this.contentActivity = contentActivity;
     }
     public void updateBoard(String content) {
         this.content = content;

--- a/src/main/java/com/example/gasip/board/model/Board.java
+++ b/src/main/java/com/example/gasip/board/model/Board.java
@@ -19,6 +19,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.example.gasip.board.model.ContentActivity.GENERAL;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -62,6 +64,19 @@ public class Board extends BaseTimeEntity {
     private List<Comment> comments = new ArrayList<>();
 
 //    @Column(nullable = false)
+//    @Schema(description = "삭제 여부")
+//    @ColumnDefault("0")
+//    private Long deleted;
+
+    @Column(nullable = false)
+    @Schema(description = "신고 횟수")
+    @ColumnDefault("0")
+    private Long reportCount;
+
+    @Enumerated(EnumType.STRING)
+    private ContentActivity contentActivity = GENERAL;
+
+//    @Column(nullable = false)
 //    @Schema(description = "교수 평점")
 //    @ColumnDefault("0")
 //    private int gradePoint;
@@ -70,7 +85,7 @@ public class Board extends BaseTimeEntity {
     private Boolean isLike;
 
 
-    public Board(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, Professor professor, Member member, List<Comment>comments) {
+    public Board(LocalDateTime regDate, LocalDateTime updateDate, Long postId, String content, Long clickCount, Long likeCount, Professor professor, Member member, List<Comment>comments, ContentActivity contentActivity) {
         super(regDate, updateDate);
         this.postId = postId;
         this.content = content;
@@ -79,6 +94,7 @@ public class Board extends BaseTimeEntity {
         this.professor = professor;
         this.member = member;
         this.comments = comments;
+        this.contentActivity = (contentActivity != null) ? contentActivity : ContentActivity.GENERAL;
     }
     public void updateBoard(String content) {
         this.content = content;
@@ -91,5 +107,10 @@ public class Board extends BaseTimeEntity {
 
     public void updateLike(Boolean isLike) {
         this.isLike=isLike;
+    }
+
+    public void changeActivity(ContentActivity contentActivity) {
+        this.contentActivity = contentActivity;
+        this.updateDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/gasip/board/model/Board.java
+++ b/src/main/java/com/example/gasip/board/model/Board.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -24,6 +26,8 @@ import java.util.List;
 @SuperBuilder
 @Schema(description = "게시글 관련된 VO")
 @DynamicInsert
+@SQLDelete(sql = "UPDATE board SET deleted = true WHERE post_id = ?")
+@Where(clause = "deleted = false")
 public class Board extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/example/gasip/board/model/ContentActivity.java
+++ b/src/main/java/com/example/gasip/board/model/ContentActivity.java
@@ -1,0 +1,14 @@
+package com.example.gasip.board.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ContentActivity {
+    GENERAL("일반 컨텐츠"),
+    FLAGGED("선정성이 있는 컨텐츠"),
+    RESTRICTED("제한된 컨텐츠");
+
+    private final String description;
+}

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustom.java
@@ -22,6 +22,8 @@ public interface BoardRepositoryCustom {
 
     void addViewCount(Board board);
 
+    void addReportCount(Board board);
+    void subReportCount(Board board);
 
     List<BoardReadResponse> findBestBoard();
 

--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
@@ -216,6 +216,26 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
                 .execute();
     }
 
+    /**
+     * 신고 관련 기능
+     */
+    @Override
+    public void addReportCount(Board selectedBoard) {
+        queryFactory.update(board)
+                .set(board.reportCount, board.reportCount.add(1))
+                .where(board.eq(selectedBoard))
+                .execute();
+    }
+
+    @Override
+    public void subReportCount(Board selectedBoard) {
+        queryFactory.update(board)
+                .set(board.reportCount, board.reportCount.subtract(1))
+                .where(board.eq(selectedBoard))
+                .execute();
+    }
+
+
     private BooleanExpression idEqual(Long id) {
         return (id == null) ? null : member.memberId.eq(id);
     }

--- a/src/main/java/com/example/gasip/board/service/BoardService.java
+++ b/src/main/java/com/example/gasip/board/service/BoardService.java
@@ -186,7 +186,7 @@ public class BoardService {
         validatedBoardWritterEqualMember(memberDetails, postId);
 
         if (board.getContentActivity() != ContentActivity.FLAGGED) {
-            throw new SelfBoardReportException(ErrorCode.CANNOT_REPORT_YOURSELF);
+            throw new CheckFlaggedException(ErrorCode.CHECK_FLAGGED_CONTENT);
         }
 
         board.changeActivity(ContentActivity.RESTRICTED);

--- a/src/main/java/com/example/gasip/boardReport/controller/BoardReportController.java
+++ b/src/main/java/com/example/gasip/boardReport/controller/BoardReportController.java
@@ -1,0 +1,35 @@
+package com.example.gasip.boardReport.controller;
+
+import com.example.gasip.boardReport.dto.BoardReportRequestDto;
+import com.example.gasip.boardReport.service.BoardReportService;
+import com.example.gasip.global.entity.HttpResponseEntity;
+import com.example.gasip.global.security.MemberDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.gasip.global.entity.HttpResponseEntity.success;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("boards/report")
+public class BoardReportController {
+    private final BoardReportService boardReportService;
+
+    @PostMapping
+    public HttpResponseEntity.ResponseResult<?> insert(@RequestBody @Valid BoardReportRequestDto boardReportRequestDto,
+                                                       @AuthenticationPrincipal MemberDetails memberDetails) throws  Exception {
+        boardReportService.insert(boardReportRequestDto, memberDetails);
+        return success();
+    }
+
+    @DeleteMapping
+    public HttpResponseEntity.ResponseResult<?> delete(@RequestBody @Valid BoardReportRequestDto boardReportRequestDto,
+                                                       @AuthenticationPrincipal MemberDetails memberDetails) throws  Exception {
+        boardReportService.delete(boardReportRequestDto, memberDetails);
+        return success();
+    }
+}

--- a/src/main/java/com/example/gasip/boardReport/dto/BoardReportRequestDto.java
+++ b/src/main/java/com/example/gasip/boardReport/dto/BoardReportRequestDto.java
@@ -1,0 +1,28 @@
+package com.example.gasip.boardReport.dto;
+
+import com.example.gasip.boardReport.model.BoardReport;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+public class BoardReportRequestDto {
+    private Long postId;
+    private String content;
+
+    @QueryProjection
+    public BoardReportRequestDto(Long postId, String content) {
+        this.postId = postId;
+        this.content = content;
+    }
+
+    public static BoardReportRequestDto toEntity(BoardReport boardReport) {
+        return BoardReportRequestDto.builder()
+                .postId(boardReport.getBoard().getPostId())
+                .content(boardReport.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/boardReport/dto/BoardReportResponseDto.java
+++ b/src/main/java/com/example/gasip/boardReport/dto/BoardReportResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.gasip.boardReport.dto;
+
+import com.example.gasip.boardReport.model.BoardReport;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+@AllArgsConstructor
+public class BoardReportResponseDto {
+    private Long reportId;
+    private Long postId;
+    private Long memberId;
+    private String content;
+
+    public static BoardReportResponseDto fromEntity(BoardReport boardReport) {
+        return BoardReportResponseDto.builder()
+                .reportId(boardReport.getReportId())
+                .postId(boardReport.getBoard().getPostId())
+                .memberId(boardReport.getMember().getMemberId())
+                .content(boardReport.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/boardReport/model/BoardReport.java
+++ b/src/main/java/com/example/gasip/boardReport/model/BoardReport.java
@@ -1,0 +1,44 @@
+package com.example.gasip.boardReport.model;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.member.model.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "BoardReport")
+@SuperBuilder
+public class BoardReport{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Board board;
+    @Column(nullable = false,length = 500)
+    private String content;
+    @Column(name = "reported_at")
+    private LocalDateTime reportedAt;
+
+    @PostPersist
+    private void setCreatedAt() {
+        reportedAt = LocalDateTime.now();
+    }
+
+    public BoardReport(Member member, Board board, String content) {
+        this.member = member;
+        this.board = board;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/example/gasip/boardReport/repository/BoardReportRepository.java
+++ b/src/main/java/com/example/gasip/boardReport/repository/BoardReportRepository.java
@@ -1,0 +1,16 @@
+package com.example.gasip.boardReport.repository;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.boardReport.model.BoardReport;
+import com.example.gasip.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoardReportRepository extends JpaRepository<BoardReport, Long> {
+    Optional<BoardReport> findByMemberAndBoard(Member member, Board board);
+
+    Boolean existsByBoard_PostIdAndMember_MemberId(Long boardId, Long memberId);
+
+    Integer countByBoard_PostId(Long boardId);
+}

--- a/src/main/java/com/example/gasip/boardReport/service/BoardReportService.java
+++ b/src/main/java/com/example/gasip/boardReport/service/BoardReportService.java
@@ -1,0 +1,80 @@
+package com.example.gasip.boardReport.service;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.board.model.ContentActivity;
+import com.example.gasip.board.repository.BoardRepository;
+import com.example.gasip.boardReport.dto.BoardReportRequestDto;
+import com.example.gasip.boardReport.model.BoardReport;
+import com.example.gasip.boardReport.repository.BoardReportRepository;
+import com.example.gasip.global.constant.ErrorCode;
+import com.example.gasip.global.exception.SelfBoardReportException;
+import com.example.gasip.global.exception.handler.DuplicateReportException;
+import com.example.gasip.global.security.MemberDetails;
+import com.example.gasip.member.model.Member;
+import com.example.gasip.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.webjars.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class BoardReportService {
+    private static final int REPORT_LIMIT = 1;
+    private final BoardReportRepository boardReportRepository;
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public void insert(BoardReportRequestDto boardReportRequestDto, MemberDetails memberDetails) throws Exception {
+        Member member = memberRepository.getReferenceById(memberDetails.getId());
+
+        Board board = boardRepository.findById(boardReportRequestDto.getPostId())
+                .orElseThrow(() -> new NotFoundException("Could not found board id : " + boardReportRequestDto.getPostId()));
+
+        validateSelfReport(memberDetails.getId(), board.getMember().getMemberId());
+
+        if (boardReportRepository.findByMemberAndBoard(member, board).isPresent()) {
+            throw new DuplicateReportException(ErrorCode.DUPLICATE_REPORT);
+        }
+
+        if (boardReportRepository.countByBoard_PostId(boardReportRequestDto.getPostId()) > REPORT_LIMIT) {
+            board.changeActivity(ContentActivity.FLAGGED);
+        }
+
+        BoardReport boardReport = BoardReport.builder()
+                .board(board)
+                .member(member)
+                .content(boardReportRequestDto.getContent())
+                .build();
+
+        boardReportRepository.save(boardReport);
+        boardRepository.addReportCount(board);
+    }
+
+    @Transactional
+    public void delete(BoardReportRequestDto boardReportRequestDto, MemberDetails memberDetails) {
+
+        Member member = memberRepository.getReferenceById(memberDetails.getId());
+
+        Board board = boardRepository.findById(boardReportRequestDto.getPostId())
+                .orElseThrow(() -> new NotFoundException("Could not found board id : " + boardReportRequestDto.getPostId()));
+
+        BoardReport boardReport = boardReportRepository.findByMemberAndBoard(member, board)
+                .orElseThrow(() -> new NotFoundException("Could not found report id"));
+
+        boardReportRepository.delete(boardReport);
+        boardRepository.subReportCount(board);
+    }
+
+    @Transactional
+    public Boolean isReport(Long postId, Long memberId) {
+        return boardReportRepository.existsByBoard_PostIdAndMember_MemberId(postId, memberId);
+    }
+
+    private void validateSelfReport(Long reporterId, Long reportedUId) {
+        if (reporterId == reportedUId) {
+            throw new SelfBoardReportException(ErrorCode.CANNOT_REPORT_YOURSELF);
+        }
+    }
+}

--- a/src/main/java/com/example/gasip/comment/dto/CommentChildrenReadResponse.java
+++ b/src/main/java/com/example/gasip/comment/dto/CommentChildrenReadResponse.java
@@ -1,5 +1,6 @@
 package com.example.gasip.comment.dto;
 
+import com.example.gasip.board.model.ContentActivity;
 import com.example.gasip.comment.model.Comment;
 import com.example.gasip.global.entity.BaseTimeEntity;
 import lombok.AllArgsConstructor;
@@ -23,6 +24,7 @@ public class CommentChildrenReadResponse extends BaseTimeEntity implements Seria
     private Boolean isCommentLike;
     private Long parentId;
     private String nickName;
+    private ContentActivity contentActivity;
 
     public static CommentChildrenReadResponse fromEntity(Comment comment) {
         return CommentChildrenReadResponse.builder()
@@ -37,6 +39,7 @@ public class CommentChildrenReadResponse extends BaseTimeEntity implements Seria
             .isCommentLike(comment.getIsCommentLike())
             .parentId(comment.getParentComment().getCommentId())
             .nickName(comment.getMember().getNickname())
+            .contentActivity(comment.getContentActivity())
             .build();
     }
 }

--- a/src/main/java/com/example/gasip/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/gasip/comment/dto/CommentCreateRequest.java
@@ -1,6 +1,7 @@
 package com.example.gasip.comment.dto;
 
 import com.example.gasip.board.model.Board;
+import com.example.gasip.board.model.ContentActivity;
 import com.example.gasip.comment.model.Comment;
 import com.example.gasip.member.model.Member;
 import lombok.AccessLevel;
@@ -14,6 +15,7 @@ import lombok.NoArgsConstructor;
 public class CommentCreateRequest{
     private String content;
     private Long parentId;
+    private ContentActivity contentActivity = ContentActivity.GENERAL;
 
     public Comment toEntity(Board board, Member member) {
         return Comment.builder()
@@ -21,6 +23,8 @@ public class CommentCreateRequest{
                 .member(member)
                 .content(content)
                 .commentLike(0L)
+                .reportCount(0L)
+                .contentActivity(contentActivity)
                 .build();
     }
 }

--- a/src/main/java/com/example/gasip/comment/dto/CommentReadResponse.java
+++ b/src/main/java/com/example/gasip/comment/dto/CommentReadResponse.java
@@ -1,5 +1,6 @@
 package com.example.gasip.comment.dto;
 
+import com.example.gasip.board.model.ContentActivity;
 import com.example.gasip.comment.model.Comment;
 import com.example.gasip.global.entity.BaseTimeEntity;
 import lombok.AllArgsConstructor;
@@ -24,6 +25,7 @@ public class CommentReadResponse extends BaseTimeEntity implements Serializable 
     private String content;
     private Long commentLike;
     private Boolean isCommentLike;
+    private ContentActivity contentActivity;
     private List<CommentChildrenReadResponse> commentChildren = new ArrayList<>();
 
     public static CommentReadResponse fromEntity(Comment comment) {
@@ -47,6 +49,7 @@ public class CommentReadResponse extends BaseTimeEntity implements Serializable 
             .content(comment.getContent())
             .commentLike(comment.getCommentLike())
             .isCommentLike(comment.getIsCommentLike())
+            .contentActivity(comment.getContentActivity())
             .commentChildren(comment.getCommentChildren()
                 .stream()
                 .map(CommentChildrenReadResponse::fromEntity)

--- a/src/main/java/com/example/gasip/comment/model/Comment.java
+++ b/src/main/java/com/example/gasip/comment/model/Comment.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,6 +25,8 @@ import java.util.List;
 @AllArgsConstructor
 @SuperBuilder
 @DynamicInsert
+@SQLDelete(sql = "UPDATE comment SET deleted = true WHERE comment_id = ?")
+@Where(clause = "deleted = false")
 public class Comment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/gasip/comment/model/Comment.java
+++ b/src/main/java/com/example/gasip/comment/model/Comment.java
@@ -1,8 +1,10 @@
 package com.example.gasip.comment.model;
 
 import com.example.gasip.board.model.Board;
+import com.example.gasip.board.model.ContentActivity;
 import com.example.gasip.global.entity.BaseTimeEntity;
 import com.example.gasip.member.model.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,6 +19,8 @@ import org.hibernate.annotations.Where;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.example.gasip.board.model.ContentActivity.GENERAL;
 
 @Entity
 @Getter
@@ -53,6 +57,14 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE)
     private List<Comment> commentChildren = new ArrayList<>();
 
+    @Column(nullable = false)
+    @Schema(description = "신고 횟수")
+    @ColumnDefault("0")
+    private Long reportCount;
+
+    @Enumerated(EnumType.STRING)
+    private ContentActivity contentActivity = GENERAL;
+
     @Transient
     private Boolean isCommentLike;
 
@@ -71,6 +83,11 @@ public class Comment extends BaseTimeEntity {
 
     public void updateCommentLike(Boolean isCommentLike) {
         this.isCommentLike=isCommentLike;
+    }
+
+    public void changeActivity(ContentActivity contentActivity) {
+        this.contentActivity = contentActivity;
+        this.updateDate = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/example/gasip/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/example/gasip/comment/repository/CommentRepositoryCustom.java
@@ -6,4 +6,7 @@ public interface CommentRepositoryCustom {
     void addCommentLikeCount(Comment comment);
 
     void subCommentLikeCount(Comment comment);
+
+    void addReportCount(Comment comment);
+    void subReportCount(Comment comment);
 }

--- a/src/main/java/com/example/gasip/comment/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/comment/repository/CommentRepositoryCustomImpl.java
@@ -25,4 +25,23 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
                 .where(comment.eq(selectedComment))
                 .execute();
     }
+
+    /**
+     * 신고 관련 기능
+     */
+    @Override
+    public void addReportCount(Comment selectedComment) {
+        queryFactory.update(comment)
+                .set(comment.reportCount, comment.reportCount.add(1))
+                .where(comment.eq(selectedComment))
+                .execute();
+    }
+
+    @Override
+    public void subReportCount(Comment selectedComment) {
+        queryFactory.update(comment)
+                .set(comment.reportCount, comment.reportCount.subtract(1))
+                .where(comment.eq(selectedComment))
+                .execute();
+    }
 }

--- a/src/main/java/com/example/gasip/commentReport/controller/CommentReportController.java
+++ b/src/main/java/com/example/gasip/commentReport/controller/CommentReportController.java
@@ -1,0 +1,36 @@
+package com.example.gasip.commentReport.controller;
+
+import com.example.gasip.commentReport.dto.CommentReportRequestDto;
+import com.example.gasip.commentReport.service.CommentReportService;
+import com.example.gasip.global.entity.HttpResponseEntity;
+import com.example.gasip.global.security.MemberDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static com.example.gasip.global.entity.HttpResponseEntity.success;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("comments/report")
+public class CommentReportController {
+    private final CommentReportService commentReportService;
+
+    @PostMapping
+    public HttpResponseEntity.ResponseResult<?> inset(@RequestBody @Valid CommentReportRequestDto commentReportRequestDto,
+                                                      @AuthenticationPrincipal MemberDetails memberDetails) throws Exception {
+        commentReportService.commentReportInsert(commentReportRequestDto, memberDetails);
+        return success();
+    }
+
+    @DeleteMapping
+    public HttpResponseEntity.ResponseResult<?> delete(@RequestBody @Valid CommentReportRequestDto commentReportRequestDto,
+                                                      @AuthenticationPrincipal MemberDetails memberDetails) throws Exception {
+        commentReportService.commentReportDelete(commentReportRequestDto, memberDetails);
+        return success();
+    }
+
+}

--- a/src/main/java/com/example/gasip/commentReport/dto/CommentReportRequestDto.java
+++ b/src/main/java/com/example/gasip/commentReport/dto/CommentReportRequestDto.java
@@ -1,0 +1,31 @@
+package com.example.gasip.commentReport.dto;
+
+import com.example.gasip.commentReport.model.CommentReport;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+public class CommentReportRequestDto {
+    private Long postId;
+    private Long commentId;
+    private String content;
+
+    @QueryProjection
+    public CommentReportRequestDto(Long postId, Long commentId, String content) {
+        this.postId = postId;
+        this.commentId = commentId;
+        this.content = content;
+    }
+
+    public static CommentReportRequestDto toEntity(CommentReport commentReport) {
+        return CommentReportRequestDto.builder()
+                .postId(commentReport.getBoard().getPostId())
+                .commentId(commentReport.getComment().getCommentId())
+                .content(commentReport.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/commentReport/dto/CommentReportResponseDto.java
+++ b/src/main/java/com/example/gasip/commentReport/dto/CommentReportResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.gasip.commentReport.dto;
+
+import com.example.gasip.commentReport.model.CommentReport;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor
+@SuperBuilder
+@AllArgsConstructor
+public class CommentReportResponseDto {
+    private Long reportId;
+    private Long memberId;
+    private Long postId;
+    private Long commentId;
+    private String content;
+
+    public static CommentReportResponseDto fromEntity(CommentReport commentReport) {
+        return CommentReportResponseDto.builder()
+                .reportId(commentReport.getReportId())
+                .memberId(commentReport.getMember().getMemberId())
+                .postId(commentReport.getBoard().getPostId())
+                .commentId(commentReport.getComment().getCommentId())
+                .content(commentReport.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gasip/commentReport/model/CommentReport.java
+++ b/src/main/java/com/example/gasip/commentReport/model/CommentReport.java
@@ -1,0 +1,48 @@
+package com.example.gasip.commentReport.model;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.comment.model.Comment;
+import com.example.gasip.member.model.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "CommentReport")
+@SuperBuilder
+public class CommentReport {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Board board;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+    @Column(nullable = false,length = 500)
+    private String content;
+    @Column(name = "reported_at")
+    private LocalDateTime reportedAt;
+
+    @PostPersist
+    private void setCreatedAt() {
+        reportedAt = LocalDateTime.now();
+    }
+
+    public CommentReport(Member member, Board board, Comment comment, String content) {
+        this.member = member;
+        this.board = board;
+        this.comment = comment;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/gasip/commentReport/repository/CommentReportRepository.java
+++ b/src/main/java/com/example/gasip/commentReport/repository/CommentReportRepository.java
@@ -1,0 +1,17 @@
+package com.example.gasip.commentReport.repository;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.comment.model.Comment;
+import com.example.gasip.commentReport.model.CommentReport;
+import com.example.gasip.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
+    Optional<CommentReport> findByMemberAndCommentAndBoard(Member member, Comment comment, Board board);
+
+    Boolean existsByComment_CommentIdAndMember_MemberId(Long commentId, Long memberId);
+
+    Integer countByComment_CommentId(Long commentId);
+}

--- a/src/main/java/com/example/gasip/commentReport/service/CommentReportService.java
+++ b/src/main/java/com/example/gasip/commentReport/service/CommentReportService.java
@@ -1,0 +1,88 @@
+package com.example.gasip.commentReport.service;
+
+import com.example.gasip.board.model.Board;
+import com.example.gasip.board.model.ContentActivity;
+import com.example.gasip.board.repository.BoardRepository;
+import com.example.gasip.comment.model.Comment;
+import com.example.gasip.comment.repository.CommentRepository;
+import com.example.gasip.commentReport.dto.CommentReportRequestDto;
+import com.example.gasip.commentReport.model.CommentReport;
+import com.example.gasip.commentReport.repository.CommentReportRepository;
+import com.example.gasip.global.constant.ErrorCode;
+import com.example.gasip.global.exception.DuplicateResourceException;
+import com.example.gasip.global.exception.SelfBoardReportException;
+import com.example.gasip.global.security.MemberDetails;
+import com.example.gasip.member.model.Member;
+import com.example.gasip.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.webjars.NotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReportService {
+    private static final int REPORT_LIMIT = 1;
+    private final CommentReportRepository commentReportRepository;
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void commentReportInsert(CommentReportRequestDto commentReportRequestDto, MemberDetails memberDetails) throws Exception {
+
+        Member member = memberRepository.getReferenceById(memberDetails.getId());
+
+        Board board = boardRepository.getReferenceById(commentReportRequestDto.getPostId());
+
+        Comment comment = commentRepository.getReferenceById(commentReportRequestDto.getCommentId());
+
+        if (commentReportRepository.findByMemberAndCommentAndBoard(member, comment, board).isPresent()) {
+            throw new DuplicateResourceException(ErrorCode.DUPLICATE_LIKE);
+        }
+
+        if (commentReportRepository.countByComment_CommentId(commentReportRequestDto.getCommentId()) > REPORT_LIMIT) {
+            comment.changeActivity(ContentActivity.FLAGGED);
+        }
+
+        CommentReport commentReport = CommentReport.builder()
+                .member(member)
+                .comment(comment)
+                .board(board)
+                .content(commentReportRequestDto.getContent())
+                .build();
+
+        commentReportRepository.save(commentReport);
+        commentRepository.addReportCount(comment);
+
+    }
+
+    @Transactional
+    public void commentReportDelete(CommentReportRequestDto commentReportRequestDto, MemberDetails memberDetails) {
+
+        Member member = memberRepository.getReferenceById(memberDetails.getId());
+
+        Board board = boardRepository.getReferenceById(commentReportRequestDto.getPostId());
+
+        Comment comment = commentRepository.findById(commentReportRequestDto.getCommentId())
+                .orElseThrow(() -> new NotFoundException(("Could not found comment id : " + commentReportRequestDto.getCommentId())));
+
+        CommentReport commentReport = commentReportRepository.findByMemberAndCommentAndBoard(member, comment, board)
+                .orElseThrow(() -> new NotFoundException("Could not found report id"));
+
+        commentReportRepository.save(commentReport);
+        commentRepository.subReportCount(comment);
+    }
+
+
+    @Transactional
+    public Boolean isReport(Long commentId, Long memberId) {
+        return commentReportRepository.existsByComment_CommentIdAndMember_MemberId(commentId, memberId);
+    }
+
+    private void validateSelfReport(Long reporterId, Long reportedUId) {
+        if (reporterId == reportedUId) {
+            throw new SelfBoardReportException(ErrorCode.CANNOT_REPORT_YOURSELF);
+        }
+    }
+}

--- a/src/main/java/com/example/gasip/commentReport/service/CommentReportService.java
+++ b/src/main/java/com/example/gasip/commentReport/service/CommentReportService.java
@@ -9,8 +9,8 @@ import com.example.gasip.commentReport.dto.CommentReportRequestDto;
 import com.example.gasip.commentReport.model.CommentReport;
 import com.example.gasip.commentReport.repository.CommentReportRepository;
 import com.example.gasip.global.constant.ErrorCode;
-import com.example.gasip.global.exception.DuplicateResourceException;
 import com.example.gasip.global.exception.SelfBoardReportException;
+import com.example.gasip.global.exception.handler.DuplicateReportException;
 import com.example.gasip.global.security.MemberDetails;
 import com.example.gasip.member.model.Member;
 import com.example.gasip.member.repository.MemberRepository;
@@ -38,7 +38,7 @@ public class CommentReportService {
         Comment comment = commentRepository.getReferenceById(commentReportRequestDto.getCommentId());
 
         if (commentReportRepository.findByMemberAndCommentAndBoard(member, comment, board).isPresent()) {
-            throw new DuplicateResourceException(ErrorCode.DUPLICATE_LIKE);
+            throw new DuplicateReportException(ErrorCode.DUPLICATE_REPORT);
         }
 
         if (commentReportRepository.countByComment_CommentId(commentReportRequestDto.getCommentId()) > REPORT_LIMIT) {

--- a/src/main/java/com/example/gasip/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/gasip/global/constant/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     DUPLICATE_PHONENUMBER("이미 존재하는 휴대폰 번호"),
     DUPLICATE_REPORT("신고 중복 오류"),
     CANNOT_REPORT_YOURSELF("자신이 작성한 글을 신고할 수 없습니다."),
+    CHECK_FLAGGED_CONTENT("신고된 게시글만 상태를 변경할 수 있습니다."),
 
     // Member
     NOT_FOUND_MEMBER("회원 정보가 없습니다. 로그인 후 이용해주세요."),

--- a/src/main/java/com/example/gasip/global/constant/ErrorCode.java
+++ b/src/main/java/com/example/gasip/global/constant/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     DUPLICATE_LIKE("좋아요 중복 오류"),
     NO_STOCK_ERROR("재고 부족 오류"),
     DUPLICATE_PHONENUMBER("이미 존재하는 휴대폰 번호"),
+    DUPLICATE_REPORT("신고 중복 오류"),
+    CANNOT_REPORT_YOURSELF("자신이 작성한 글을 신고할 수 없습니다."),
 
     // Member
     NOT_FOUND_MEMBER("회원 정보가 없습니다. 로그인 후 이용해주세요."),

--- a/src/main/java/com/example/gasip/global/exception/CheckFlaggedException.java
+++ b/src/main/java/com/example/gasip/global/exception/CheckFlaggedException.java
@@ -1,0 +1,12 @@
+package com.example.gasip.global.exception;
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class CheckFlaggedException extends BaseException {
+    private final ErrorCode errorCode;
+
+    public CheckFlaggedException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/SelfBoardReportException.java
+++ b/src/main/java/com/example/gasip/global/exception/SelfBoardReportException.java
@@ -1,0 +1,11 @@
+package com.example.gasip.global.exception;
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class SelfBoardReportException extends BaseException {
+    private final ErrorCode errorCode;
+    public SelfBoardReportException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/gasip/global/exception/handler/DuplicateReportException.java
+++ b/src/main/java/com/example/gasip/global/exception/handler/DuplicateReportException.java
@@ -1,0 +1,11 @@
+package com.example.gasip.global.exception.handler;
+
+import com.example.gasip.global.constant.ErrorCode;
+
+public class DuplicateReportException extends RuntimeException {
+    private ErrorCode errorCode;
+    public DuplicateReportException(ErrorCode errorCode) {
+        super(ErrorCode.DUPLICATE_REPORT.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
## 작업 요약
- 게시글 신고 기능 구현
- 댓글 신고 기능 구현
- board 및 comment 테이블에 contentActivity, report_count 필드 추가
## Issue Link
#475 
## 문제점 및 어려움
- 동시성 처리 및 성능 개선 필요
## 해결 방안
- 추후 redis 사용하여 리팩토링 예정
## Reference
