### PR TITLE
refactor : 커버링 인덱스 추가

### DIFF
--- a/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/example/gasip/board/repository/BoardRepositoryCustomImpl.java
@@ -104,11 +104,16 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
 
         List<Long> blockedIds = getBlockedIds(blockerId);
 
-        List<Long> prof_ids = queryFactory
+        List<Long> postIds = queryFactory
                 .select(board.postId)
                 .from(board)
-                .leftJoin(board.professor, professor)
-                .where(board.professor.profId.gt(0L).and(board.contentActivity.eq(ContentActivity.GENERAL)))
+                .where(
+                        board.professor.profId.gt(0L),
+                        board.contentActivity.eq(ContentActivity.GENERAL)
+                )
+                .orderBy(board.regDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
         List<BoardReadResponse> boardReadResponses = queryFactory
@@ -119,12 +124,10 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
                         board.professor.category.majorName, board.contentActivity))
                 .from(board)
                 .leftJoin(board.professor, professor)
-                .where(board.professor.profId.gt(0).and(board.member.memberId.notIn(blockedIds)))
-//                .where(board.postId.in(prof_ids).and(board.member.memberId.notIn(blockedIds)))
+                .where(board.postId.in(postIds).and(board.member.memberId.notIn(blockedIds)))
                 .orderBy(board.regDate.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
                 .fetch();
+
         return new PageImpl<>(boardReadResponses);
     }
 


### PR DESCRIPTION
Resolves: #510

## 작업 요약
- 페이지네이션 성능 개선을 위한 커버링 인덱스 추가 
- professor_id, content_activity, reg_date DESC, post_id 복합 인덱스 생성 
- Cluster Key (PK)를 커버링 인덱스로 조회 후 select 컬럼을 후속 조회
## Issue Link
#510 
## 문제점 및 어려움
- select / where / order by / group by 등에서 사용되는 모든 컬럼이 인덱스에 포함시키는 적절한 값을 찾는것이 어려웠다. 
## 해결 방안
- Cluster Key (PK)를 커버링 인덱스로 조회 후 select 컬럼을 후속 조회
## Reference
https://www.youtube.com/watch?v=zMAX7g6rO_Y